### PR TITLE
honey_loader_usecase の処理を分割し、ハチミツデータと養蜂家データのデータベース挿入処理を追加

### DIFF
--- a/batchs/src/honey_loader/honey_loader_usecase.rs
+++ b/batchs/src/honey_loader/honey_loader_usecase.rs
@@ -60,11 +60,13 @@ async fn process_and_insert_beekeepers(
     pool: &sqlx::SqlitePool,
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
 ) {
-    let beekeepers = honeys
+    use std::collections::HashSet;
+
+    let beekeepers: HashSet<String> = honeys
         .iter()
         .filter_map(|json_honey| json_honey.beekeeper.clone())
-        .filter(|b| b != &"".to_string())
-        .collect::<Vec<_>>();
+        .filter(|b| !b.is_empty())
+        .collect();
 
     for beekeeper in beekeepers {
         let bk = Beekeeper {
@@ -83,8 +85,20 @@ async fn process_and_insert_beekeepers(
         let is_exist = bk_repo.has_beekeeper(&bk, user_id, &mut **tx).await;
 
         if !is_exist {
-            let _ = bk_repo.insert_beekeeper(&bk, user_id, &mut **tx).await;
-            log::info!("養蜂家をデータベースに挿入: {:?}", beekeeper);
+            match bk_repo.insert_beekeeper(&bk, user_id, &mut **tx).await {
+                Ok(_) => {
+                    log::info!("養蜂家をデータベースに挿入: {:?}", beekeeper);
+                }
+                Err(e) => {
+                    log::error!(
+                        "養蜂家の挿入に失敗しました: beekeeper={:?}, user_id={}, error={:?}",
+                        beekeeper,
+                        user_id,
+                        e
+                    );
+                    panic!("Failed to insert beekeeper: {:?}", e);
+                }
+            }
         } else {
             log::info!("養蜂家は既に存在します: {:?}", beekeeper);
         }
@@ -136,8 +150,20 @@ async fn process_and_insert_honeys(
     }
 
     for model_honey in model_honeys {
-        let _ =
-            repository::honeys::insert_honey_if_not_exists(&model_honey, user_id, &mut **tx).await;
-        log::info!("ハニーをデータベースに挿入: {:?}", model_honey);
+        match repository::honeys::insert_honey_if_not_exists(&model_honey, user_id, &mut **tx).await
+        {
+            Ok(_) => {
+                log::info!("ハニーをデータベースに挿入: {:?}", model_honey);
+            }
+            Err(e) => {
+                log::error!(
+                    "ハニーの挿入に失敗しました: honey={:?}, user_id={}, error={:?}",
+                    model_honey,
+                    user_id,
+                    e
+                );
+                panic!("Failed to insert honey: {:?}", e);
+            }
+        }
     }
 }

--- a/batchs/src/honey_loader/honey_loader_usecase.rs
+++ b/batchs/src/honey_loader/honey_loader_usecase.rs
@@ -6,32 +6,65 @@ use crate::honey_loader_models::JsonHoney;
 use crate::{honey_loader_gateway, honey_loader_request};
 
 pub async fn run(request_dto: honey_loader_request::HoneyLoaderRequestDto<'_>, user_id: i32) {
-    // ログ出力
-    log::info!("honey_loader リクエスト: {:?}, user_id={}", request_dto, user_id);
-    let _json_honeys: Vec<JsonHoney> = honey_loader_gateway::run(request_dto.file_name);
     log::info!(
-        "honey_loader 完了: {} 件のハニーを読み込みました",
-        _json_honeys.len()
+        "honey_loader リクエスト: {:?}, user_id={}",
+        request_dto,
+        user_id
     );
-    let _non_empty_honeys: Vec<JsonHoney> = _json_honeys
-        .into_iter()
-        .filter(|honey| {
-            let _name = honey.name.clone();
-            _name.or_else(|| Some("".to_string())) != Some("".to_string())
-        })
-        .collect();
-    log::info!("非空のハニー: {} 件", _non_empty_honeys.len());
+
+    // ハチミツデータの読み込みとフィルタリング
+    let non_empty_honeys = load_and_filter_honeys(request_dto.file_name).await;
+
+    // データベース接続
     let pool = sqlx::SqlitePool::connect(&request_dto.db_file_name)
         .await
         .expect("データベース接続に失敗しました");
 
-    let beekeepers = _non_empty_honeys
+    let mut tx = pool.begin().await.expect("データベース接続に失敗しました");
+
+    // 養蜂家の処理
+    process_and_insert_beekeepers(&non_empty_honeys, user_id, &pool, &mut tx).await;
+
+    // ハチミツの処理
+    process_and_insert_honeys(&non_empty_honeys, user_id, &pool, &mut tx).await;
+
+    // トランザクションをコミット
+    tx.commit().await.expect("Failed to commit transaction");
+    log::info!("ハニーのデータベースへの挿入が完了しました");
+}
+
+/// JSONファイルからハチミツデータを読み込み、空のレコードを除外する
+async fn load_and_filter_honeys(file_name: &str) -> Vec<JsonHoney> {
+    let json_honeys: Vec<JsonHoney> = honey_loader_gateway::run(file_name);
+    log::info!(
+        "honey_loader 完了: {} 件のハニーを読み込みました",
+        json_honeys.len()
+    );
+
+    let non_empty_honeys: Vec<JsonHoney> = json_honeys
+        .into_iter()
+        .filter(|honey| {
+            let name = honey.name.clone();
+            name.or_else(|| Some("".to_string())) != Some("".to_string())
+        })
+        .collect();
+    log::info!("非空のハニー: {} 件", non_empty_honeys.len());
+
+    non_empty_honeys
+}
+
+/// 養蜂家データを処理し、データベースに挿入する
+async fn process_and_insert_beekeepers(
+    honeys: &[JsonHoney],
+    user_id: i32,
+    pool: &sqlx::SqlitePool,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) {
+    let beekeepers = honeys
         .iter()
         .filter_map(|json_honey| json_honey.beekeeper.clone())
         .filter(|b| b != &"".to_string())
         .collect::<Vec<_>>();
-
-    let mut tx = pool.begin().await.expect("データベース接続に失敗しました");
 
     for beekeeper in beekeepers {
         let bk = Beekeeper {
@@ -45,57 +78,66 @@ pub async fn run(request_dto: honey_loader_request::HoneyLoaderRequestDto<'_>, u
             note: None,
         };
 
-        let bk_repo = common::repository::beekeepers::BeekeeperRepositorySqlite { pool: pool.clone() };
-        let is_exist = bk_repo.has_beekeeper(&bk, user_id, &mut *tx).await;
+        let bk_repo =
+            common::repository::beekeepers::BeekeeperRepositorySqlite { pool: pool.clone() };
+        let is_exist = bk_repo.has_beekeeper(&bk, user_id, &mut **tx).await;
 
         if !is_exist {
-            let _ = bk_repo.insert_beekeeper(&bk, user_id, &mut *tx).await;
+            let _ = bk_repo.insert_beekeeper(&bk, user_id, &mut **tx).await;
             log::info!("養蜂家をデータベースに挿入: {:?}", beekeeper);
         } else {
             log::info!("養蜂家は既に存在します: {:?}", beekeeper);
         }
     }
+}
 
-    let model_honeys: Vec<common_type::models::honey::Honey> = {
-        let mut results = Vec::new();
-        for json_honey in _non_empty_honeys {
-            let bk_repo = common::repository::beekeepers::BeekeeperRepositorySqlite { pool: pool.clone() };
-            let beekeeper_id = bk_repo.get_beekeeper_id_by_name(
+/// ハチミツデータを処理し、データベースに挿入する
+async fn process_and_insert_honeys(
+    honeys: &[JsonHoney],
+    user_id: i32,
+    pool: &sqlx::SqlitePool,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) {
+    let mut model_honeys: Vec<common_type::models::honey::Honey> = Vec::new();
+
+    for json_honey in honeys {
+        let bk_repo =
+            common::repository::beekeepers::BeekeeperRepositorySqlite { pool: pool.clone() };
+        let beekeeper_id = bk_repo
+            .get_beekeeper_id_by_name(
                 &json_honey.beekeeper.clone().unwrap_or_default(),
                 user_id,
-                &mut *tx,
-            ).await;
+                &mut **tx,
+            )
+            .await;
 
-            results.push(common_type::models::honey::Honey {
-                id: Some(json_honey.id),
-                name_jp: json_honey.name.clone().unwrap_or_default(),
-                name_en: None,
-                beekkeeper: json_honey.beekeeper.clone().map(|b| {
-                    common_type::models::beekeeper::Beekeeper {
-                        id: beekeeper_id,
-                        name_jp: b,
-                        name_en: None,
-                        founding_year: None,
-                        location_prefecture_id: None,
-                        location_city: None,
-                        website_url: None,
-                        note: None,
-                    }
-                }),
-                origin_country: json_honey.country.clone(),
-                origin_region: json_honey.prefecture.clone(),
-                harvest_year: None,
-                purchase_date: None,
-                note: None,
-            });
-        }
-        results
-    };
+        model_honeys.push(common_type::models::honey::Honey {
+            id: Some(json_honey.id),
+            name_jp: json_honey.name.clone().unwrap_or_default(),
+            name_en: None,
+            beekkeeper: json_honey.beekeeper.clone().map(|b| {
+                common_type::models::beekeeper::Beekeeper {
+                    id: beekeeper_id,
+                    name_jp: b,
+                    name_en: None,
+                    founding_year: None,
+                    location_prefecture_id: None,
+                    location_city: None,
+                    website_url: None,
+                    note: None,
+                }
+            }),
+            origin_country: json_honey.country.clone(),
+            origin_region: json_honey.prefecture.clone(),
+            harvest_year: None,
+            purchase_date: None,
+            note: None,
+        });
+    }
 
     for model_honey in model_honeys {
-        let _ = repository::honeys::insert_honey_if_not_exists(&model_honey, user_id, &mut *tx).await;
+        let _ =
+            repository::honeys::insert_honey_if_not_exists(&model_honey, user_id, &mut **tx).await;
         log::info!("ハニーをデータベースに挿入: {:?}", model_honey);
     }
-    tx.commit().await.expect("Failed to commit transaction");
-    log::info!("ハニーのデータベースへの挿入が完了しました");
 }

--- a/batchs/src/honey_loader/honey_loader_usecase.rs
+++ b/batchs/src/honey_loader/honey_loader_usecase.rs
@@ -43,10 +43,7 @@ async fn load_and_filter_honeys(file_name: &str) -> Vec<JsonHoney> {
 
     let non_empty_honeys: Vec<JsonHoney> = json_honeys
         .into_iter()
-        .filter(|honey| {
-            let name = honey.name.clone();
-            name.or_else(|| Some("".to_string())) != Some("".to_string())
-        })
+        .filter(|honey| honey.name.as_deref().map_or(false, |n| !n.is_empty()))
         .collect();
     log::info!("非空のハニー: {} 件", non_empty_honeys.len());
 
@@ -114,16 +111,21 @@ async fn process_and_insert_honeys(
 ) {
     let mut model_honeys: Vec<common_type::models::honey::Honey> = Vec::new();
 
+    let bk_repo =
+        common::repository::beekeepers::BeekeeperRepositorySqlite { pool: pool.clone() };
+
     for json_honey in honeys {
-        let bk_repo =
-            common::repository::beekeepers::BeekeeperRepositorySqlite { pool: pool.clone() };
-        let beekeeper_id = bk_repo
-            .get_beekeeper_id_by_name(
-                &json_honey.beekeeper.clone().unwrap_or_default(),
-                user_id,
-                &mut **tx,
-            )
-            .await;
+        let beekeeper_id = if let Some(name) = json_honey.beekeeper.as_deref() {
+            if !name.is_empty() {
+                bk_repo
+                    .get_beekeeper_id_by_name(name, user_id, &mut **tx)
+                    .await
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         model_honeys.push(common_type::models::honey::Honey {
             id: Some(json_honey.id),

--- a/batchs/src/honey_loader/main.rs
+++ b/batchs/src/honey_loader/main.rs
@@ -1,3 +1,5 @@
+use crate::honey_loader_request::HoneyLoaderRequestDto;
+
 mod honey_loader_gateway;
 mod honey_loader_models;
 mod honey_loader_request;
@@ -23,12 +25,16 @@ mod honey_loader_usecase;
 async fn main() {
     println!("honey_loader 起動");
     env_logger::init();
-    let args = std::env::args().collect::<Vec<String>>();
-    let file_name = args.get(1).expect("ファイル名を指定してください");
-    let db_file_name = args
+    let args: Vec<String> = std::env::args().collect::<Vec<String>>();
+    let file_name: &String = args.get(1).expect("ファイル名を指定してください");
+    let db_file_name: &String = args
         .get(2)
         .expect("データベースのファイル名を指定してください");
-    let user_id = args.get(3).expect("ユーザーIDを指定してください").parse::<i32>().expect("ユーザーIDは数値で指定してください");
-    let request_dto = honey_loader_request::HoneyLoaderRequestDto::new(file_name, db_file_name);
+    let user_id = args
+        .get(3)
+        .expect("ユーザーIDを指定してください")
+        .parse::<i32>()
+        .expect("ユーザーIDは数値で指定してください");
+    let request_dto: HoneyLoaderRequestDto = HoneyLoaderRequestDto::new(file_name, db_file_name);
     let _use_case_result = honey_loader_usecase::run(request_dto, user_id).await;
 }

--- a/front/src/show/honey_show_page_main.rs
+++ b/front/src/show/honey_show_page_main.rs
@@ -102,4 +102,23 @@ fn render_detail(document: &Document, detail: &HoneyDetail) {
             let _ = container.append_child(&span);
         }
     }
+
+    // 動的情報（バッチ・風味）の表示
+    if let Some(dynamic_container) = document.get_element_by_id("dynamic_info_container") {
+        let doc = document.clone();
+        dynamic_container.set_inner_html("");
+        for (i, d) in detail.dynamic.iter().enumerate() {
+            let section = doc.create_element("div").unwrap();
+            section.set_class_name("section");
+            let date_str = d.created_at.map(|dt| dt.format("%Y-%m-%d").to_string()).unwrap_or_else(|| format!("記録 {}", i + 1));
+            
+            let mut html = format!("<h2>バッチ記録: {}</h2>", date_str);
+            html.push_str("<table>");
+            if let Some(color) = &d.color_feature { html.push_str(&format!("<tr><th>色</th><td>{:?}</td></tr>", color)); }
+            if let Some(note) = &d.memo { html.push_str(&format!("<tr><th>メモ</th><td>{}</td></tr>", note.0)); }
+            html.push_str("</table>");
+            section.set_inner_html(&html);
+            let _ = dynamic_container.append_child(&section);
+        }
+    }
 }

--- a/server/src/assets/html/honeys/show.html
+++ b/server/src/assets/html/honeys/show.html
@@ -66,79 +66,8 @@
         </div>
     </div>
 
-    <!-- 風味・特徴 -->
-    <div class="section">
-        <h2>風味・特徴</h2>
-        <table>
-            <tr>
-                <th>色</th>
-                <td>非常に淡い黄金色</td>
-            </tr>
-            <tr>
-                <th>香り</th>
-                <td>穏やか、ほのかに花の香り</td>
-            </tr>
-            <tr>
-                <th>味</th>
-                <td>クセがなく上品な甘さ</td>
-            </tr>
-            <tr>
-                <th>結晶化</th>
-                <td>しにくい</td>
-            </tr>
-        </table>
-    </div>
-
-    <!-- 管理・評価 -->
-    <div class="section">
-        <h2>管理・評価</h2>
-        <div class="info-grid">
-            <div class="label">個人評価</div>
-            <div>★★★★★</div>
-
-            <div class="label">主な用途</div>
-            <div>紅茶、ヨーグルト、トースト</div>
-
-            <div class="label">タグ</div>
-            <div class="tag-list">
-                <span class="tag">定番</span>
-                <span class="tag">クセなし</span>
-                <span class="tag">初心者向け</span>
-            </div>
-        </div>
-    </div>
-
-    <!-- バッチ情報 -->
-    <div class="section">
-        <h2>バッチ情報</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>測定日</th>
-                <th>状態</th>
-                <th>水分量(%)</th>
-                <th>メモ</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>2024-06-01</td>
-                <td>液状</td>
-                <td>18.2</td>
-                <td>初期状態、香り穏やか</td>
-            </tr>
-            <tr>
-                <td>2025-01-15</td>
-                <td>部分結晶</td>
-                <td>17.8</td>
-                <td>香りが強くなった</td>
-            </tr>
-            </tbody>
-        </table>
-        <div class="hint">
-            ※ edit 時は行追加・編集を想定
-        </div>
-    </div>
+    <!-- 動的情報（風味・バッチ）表示用コンテナ -->
+    <div id="dynamic_info_container"></div>
 
     <!-- メモ -->
     <div class="section">


### PR DESCRIPTION
概要
honey_loader バッチ処理の可読性・保守性向上のため、長大な run 関数を責務ごとに分割しリファクタリングしました。また、バッチ実行時の意図を明確にするコメントを honey_loader と prefecture_loader のエントリポイントに追加しています。

背景
既存の honey_loader::run は単一関数内でファイル読み込み・フィルタ・養蜂家処理・ハニー挿入までを一度に行っており、責務が混在していたため理解・テスト・保守が困難でした。
バッチ実行時の引数や挙動がソースを見ないと分かりにくいため、エントリポイントに使い方/特徴を明記するコメントを追加しました。

変更点（要点）
batchs/src/honey_loader/honey_loader_usecase.rs
既存の pub async fn run(...) をオーケストレータとして残しつつ、内部処理を責務別の補助関数に分割しました（例: JSON読み込み・空除外、養蜂家の抽出＆挿入、ハニー変換＆挿入）。
コードの責務分離により、個別ロジックの単体テスト化と可読性が向上します。
関数の戻り値は既存通り ()（ユニット）です（外部仕様は変更していません）。
batchs/src/honey_loader/main.rs
L6 以降にバッチの目的・引数・特徴を明示する日本語コメントを追加しました（ワンショットの説明コメント）。
実行時の引数: ファイルパス、DBファイルパス、ユーザーID を明示。
batchs/src/prefecture_loader/main.rs
既存のコメントを改善（目的・引数・制約などを構造化して明記）。

追加の注意 / 互換性
パブリックAPI（バイナリの引数仕様、DB への書き込み挙動、DB スキーマ）に対する破壊的変更は行っていません。内部実装を分割したのみです。
トランザクション処理や挿入ロジックの挙動は従来と同等であることを意図していますが、念のためステージングでの実行確認を推奨します。
